### PR TITLE
Investigate sync release format error

### DIFF
--- a/.github/workflows/sync-releases.yml
+++ b/.github/workflows/sync-releases.yml
@@ -157,14 +157,18 @@ jobs:
           fi
           
           # Create release in website repository
+          cat > release_notes.txt << EOF
+          Website updated to reflect release ${{ steps.get_release.outputs.release_tag }} from the main repository.
+
+          Main Repository Release: ${{ steps.get_release.outputs.release_url }}
+
+          Changes:
+          ${{ steps.get_release.outputs.release_body }}
+          EOF
+          
           gh release create "${{ steps.get_release.outputs.release_tag }}" \
             --title "Website Update: ${{ steps.get_release.outputs.release_name }}" \
-            --notes "Website updated to reflect release ${{ steps.get_release.outputs.release_tag }} from the main repository.
-
-          **Main Repository Release**: ${{ steps.get_release.outputs.release_url }}
-
-          ### Changes
-          ${{ steps.get_release.outputs.release_body }}"
+            --notes-file release_notes.txt
 
   # Trigger website rebuild after sync
   rebuild-site:


### PR DESCRIPTION
Refactor `gh release create` command in `sync-releases.yml` to fix `Invalid format ' '` error.

The previous `--notes` parameter used a multi-line string directly within the YAML, which led to `Invalid format ' '` errors due to YAML misinterpreting markdown formatting and GitHub Actions variables. This change uses a heredoc to write the notes to a temporary file, which is then passed via `--notes-file`, bypassing the YAML parsing issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-e015ab2a-de7a-4a42-af44-6cbf5a823e98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e015ab2a-de7a-4a42-af44-6cbf5a823e98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

